### PR TITLE
Stop malicious from accessing usernames

### DIFF
--- a/web/app/themes/hmcts-km/functions.php
+++ b/web/app/themes/hmcts-km/functions.php
@@ -29,7 +29,8 @@ $sage_includes = [
 	'lib/public-metabox.php',               // Extra Metabox
 	'lib/welsh-metabox.php',               // Extra Metabox
 	'lib/users/author.php',              // Custom User Role Settings
-	'lib/users/editor.php',              // Custom User Role Settings
+  'lib/users/editor.php',              // Custom User Role Settings
+  'lib/security.php'
 ];
 
 foreach ( $sage_includes as $file ) {

--- a/web/app/themes/hmcts-km/lib/security.php
+++ b/web/app/themes/hmcts-km/lib/security.php
@@ -1,0 +1,12 @@
+<?php 
+
+# Restrict access to particular paths. Block /?author= access allowing the attacker to get usernames.
+
+add_action( 'template_redirect', 'author_page_redirect' );
+
+function author_page_redirect() {
+    if ( is_author() ) {
+        wp_redirect( home_url() );
+    }
+}
+


### PR DESCRIPTION
Redirected queries for /authors= so that the site did not display the
usernames of users.