### PR TITLE
Update git clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Anonymous users cannot view the website – users must login before seeing conte
 1. Clone this repo to your local machine.
 
     ```bash
-    git clone git@github.com:ministryofjustice/hmcts-km.git .
+    git clone git@github.com:ministryofjustice/hmcts-km.git
     rm -rf .git
     ```
 


### PR DESCRIPTION
The git clone command does not require a period '.' to clone to a local directory - in fact it interprets the period as the name of the directory to clone the repo into.