### PR TITLE
Modify order of posts on landing page

### DIFF
--- a/web/app/themes/hmcts-km/landing-page.php
+++ b/web/app/themes/hmcts-km/landing-page.php
@@ -35,7 +35,9 @@
                             'post_type' => 'post',
                             'posts_per_page' => -1,
                             'post_status' => 'publish',
-                            'category__in' => $categories
+                            'category__in' => $categories,
+                            'orderby' => 'modified',
+                            'order' => 'DESC'
                         )
                     );
 


### PR DESCRIPTION
Previously the posts were ordered by the date the post was created.
Now they are ordered by the date they were modified.